### PR TITLE
Non-normative block for navigation APIs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -425,11 +425,11 @@ interface ControlledFrame : HTMLElement {
     readonly attribute ContextMenus contextMenus;
 
     // Navigation methods.
-    undefined back();
+    Promise<undefined> back();
     boolean canGoBack();
     boolean canGoForward();
-    undefined forward();
-    undefined go();
+    Promise<undefined> forward();
+    Promise<undefined> go(long relativeIndex);
     undefined reload();
     undefined stop();
 
@@ -459,6 +459,53 @@ IWA frame will have access to a ControlledFrame element.
 <!-- ====================================================================== -->
 ## Navigation methods ## {#api-nav}
 <!-- ====================================================================== -->
+
+<div class="domintro note">
+
+  : {{ControlledFrame/go()|go}}()
+
+  :: Reloads the current page.
+
+  : {{ControlledFrame/go()|go}}(<var>relativeIndex</var>)
+
+  :: Goes back or forward the specified number of steps in the overall
+    <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#tn-session-history-entries">
+    session history entries </a> list for the current
+    <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#traversable-navigable">
+    traversable navigable</a>.
+
+    A zero relative index will reload the current page.
+
+    If the relative index is out of range, does nothing.
+
+  : {{ControlledFrame/back()|back}}()
+
+  :: Goes back one step in the overall
+    <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#tn-session-history-entries">
+    session history entries </a> list for the
+    <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#traversable-navigable">
+    traversable navigable</a> in the Controlled Frame.
+
+    If there is no previous page, does nothing.
+
+  : {{ControlledFrame/forward()|forward}}()
+
+  :: Goes forward one step in the overall
+    <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#tn-session-history-entries">
+    session history entries </a> list for the
+    <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#traversable-navigable">
+    traversable navigable</a> in the Controlled Frame.
+
+    If there is no next page, does nothing.
+
+  : {{ControlledFrame/canGoBack()|canGoBack}}()
+
+  ::
+
+</div>
+
+The {{ControlledFrame/back()}} method, when invoked, MUST run the following
+steps:
 
 <!-- ====================================================================== -->
 ## Scripting methods ## {#api-scripting}

--- a/index.bs
+++ b/index.bs
@@ -500,12 +500,24 @@ IWA frame will have access to a ControlledFrame element.
 
   : {{ControlledFrame/canGoBack()|canGoBack}}()
 
-  ::
+  :: Returns true if the current
+     <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-current-history-entry">
+     current session history entry</a> is not the first one in the navigation
+     history entry list. This means that there is a previous
+     <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#session-history-entry">
+     session history entry</a> for this
+     <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#navigable">
+     navigable</a>.
+
+  : {{ControlledFrame/reload()|reload}}()
+
+  :: Reloads the current page.
+
+  : {{ControlledFrame/stop()|stop}}()
+
+  :: Cancels the document load.
 
 </div>
-
-The {{ControlledFrame/back()}} method, when invoked, MUST run the following
-steps:
 
 <!-- ====================================================================== -->
 ## Scripting methods ## {#api-scripting}

--- a/index.bs
+++ b/index.bs
@@ -468,7 +468,7 @@ IWA frame will have access to a ControlledFrame element.
 
   : {{ControlledFrame/go()|go}}(<var>relativeIndex</var>)
 
-  :: Goes back or forward the specified number of steps in the overall
+  :: Goes back or forward <var>relativeIndex</var> number of steps in the overall
     <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#tn-session-history-entries">
     session history entries </a> list for the current
     <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#traversable-navigable">


### PR DESCRIPTION
This commit adds a non-normative block to describe what the navigation APIs do. The descriptions are taken from equivalent APIs available for history (go, back, forward), navigation (canGoBack, canGoForward) and window (reload, stop).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/controlled-frame/pull/31.html" title="Last updated on Oct 31, 2023, 9:09 PM UTC (fe5cdeb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/controlled-frame/31/57a7e59...odejesush:fe5cdeb.html" title="Last updated on Oct 31, 2023, 9:09 PM UTC (fe5cdeb)">Diff</a>