### PR TITLE
executeScript: Send 'code' or 'file' args exclusive of one another

### DIFF
--- a/test_app/controlledframe_api.js
+++ b/test_app/controlledframe_api.js
@@ -580,8 +580,12 @@ class ControlledFrameController {
   }
 
   #readInjectDetails() {
+    if ($('#inject_details_code_in').value.length > 0) {
+      return {
+        code: $('#inject_details_code_in').value,
+      }
+    }
     return {
-      code: $('#inject_details_code_in').value,
       file: $('#inject_details_file_in').value,
     };
   }


### PR DESCRIPTION
When the executeScript call is made, the receiving API for this call requires that only one of 'code' or 'file' is received. Sending both at the same time will trigger a failure. Update the caller to only send one of these keys in the object arguments at a time.