### PR TITLE
test_app: Fix addContentScripts and insertCSS

### DIFF
--- a/test_app/index.html
+++ b/test_app/index.html
@@ -562,7 +562,7 @@
             <div class="checkbox"><input type="checkbox" id="content_script_details_match_about_blank_chk" /></div>
 
             <label for="content_script_details_matches_in">matches</label>
-            <input type="text" id="content_script_details_matches_in" value="https://google.com/*" />
+	    <input type="text" id="content_script_details_matches_in" value="<all_urls>" />
 
             <label for="content_script_details_name_in">name</label>
             <input type="text" id="content_script_details_name_in" value="myRule" />
@@ -578,7 +578,7 @@
             <label for="content_script_details_css_injection_items_code_in">code</label>
             <textarea id="content_script_details_css_injection_items_code_in">
 body {
-  background-color = 'red';
+  background-color: red !important;
 }
             </textarea>
 


### PR DESCRIPTION
addContentScripts() should use <all_urls> to match on. This will ensure that whatever URL the frame is displaying will match the provided JS from the test app.

insertCSS() assumes the provided value is CSS that can be applied to a given page. This commit fixes the CSS syntax used and adds !important which will override any existing CSS rules for the body's background color.