### PR TITLE
test_app: Fix insertCSS() to use a separate details section

### DIFF
--- a/test_app/controlledframe_api.js
+++ b/test_app/controlledframe_api.js
@@ -212,7 +212,7 @@ class ControlledFrameController {
       this.#getZoomMode.bind(this)
     );
     $('#go_btn').addEventListener('click', this.#go.bind(this));
-    $('#insert_css_btn').addEventListener('click', this.#insertCSS.bind(this));
+    $('#insertcss_btn').addEventListener('click', this.#insertCSS.bind(this));
     $('#is_audio_muted_btn').addEventListener(
       'click',
       this.#isAudioMuted.bind(this)
@@ -589,6 +589,17 @@ class ControlledFrameController {
     };
   }
 
+  #readInsertCSSInjectDetails() {
+    if ($('#insertcss_inject_details_code_in').value.length > 0) {
+      return {
+        code: $('#insertcss_inject_details_code_in').value,
+      }
+    }
+    return {
+      file: $('#insertcss_inject_details_file_in').value,
+    };
+  }
+
   #executeScript(e) {
     if (typeof this.controlledFrame.executeScript !== 'function') {
       Log.warn('executeScript: API undefined');
@@ -699,10 +710,10 @@ class ControlledFrameController {
       Log.warn('insertCSS: API undefined');
       return;
     }
-    let details = this.#readInjectDetails();
+    let details = this.#readInsertCSSInjectDetails();
     let callback = () => {
       Log.info('insertCSS completed');
-      $('#insert_css_result').innerText = 'Done';
+      $('#insertcss_result').innerText = 'Done';
     };
     this.controlledFrame.insertCSS(details, callback);
   }

--- a/test_app/index.html
+++ b/test_app/index.html
@@ -543,7 +543,7 @@
 
           <!-- Content injection controls -->
           <div class="subcontrols">
-            <h4>Content Injection</h4>
+            <h4>Content Scripts: Content Injection</h4>
 
             <h5>ContentScriptDetails detail</h5>
             <label for="content_script_details_all_frames_chk">all_frames</label>
@@ -604,6 +604,10 @@ body {
             <label for="remove_content_scripts_in">removeContentScripts()</label>
             <input type="text" id="remove_content_scripts_in" value="myRule" />
             <button id="remove_content_scripts_btn">Remove</button>
+          </div>
+
+          <div class="subcontrols">
+            <h4>executeScript: Content Injection</h4>
 
             <h5>InjectDetails details</h5>
             <label for="inject_details_code_in">code</label>
@@ -614,16 +618,31 @@ body {
 })();
             </textarea>
 
-            <label for="inject_details_fils_in">file</label>
+            <label for="inject_details_file_in">file</label>
             <input type="text" id="inject_details_file_in" />
 
             <label for="execute_script_result">executeScript(<br> details)</label>
             <div id="execute_script_result"></div>
             <button id="execute_script_btn">Set</button>
+          </div>
 
-            <label for="insert_css_result">insertCSS(<br> details)</label>
-            <div id="insert_css_result"></div>
-            <button id="insert_css_btn">Set</button>
+          <div class="subcontrols">
+            <h4>insertCSS: Content Injection</h4>
+
+            <h5>InjectDetails details</h5>
+            <label for="insertcss_inject_details_code_in">code</label>
+            <textarea id="insertcss_inject_details_code_in">
+body {
+  background-color: red !important;
+}
+            </textarea>
+
+            <label for="insertcss_inject_details_file_in">file</label>
+            <input type="text" id="insertcss_inject_details_file_in" />
+
+            <label for="insertcss_result">insertCSS(<br> details)</label>
+            <div id="insertcss_result"></div>
+            <button id="insertcss_btn">Set</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
insertCSS() should use a separate details section since it will require CSS by default which the test app can supply.

While here, add headings to break up the different content injection settings.