### PR TITLE
spec: Define scripting methods IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -434,10 +434,10 @@ interface ControlledFrame : HTMLElement {
     undefined stop();
 
     // Scripting methods.
-    undefined addContentScripts();
-    undefined executeScript();
-    undefined insertCSS();
-    undefined removeContentScripts();
+    undefined addContentScripts(sequence<ContentScriptDetails> contentScriptList);
+    Promise<any> executeScript(InjectDetails? details);
+    Promise<undefined> insertCSS(InjectDetails? details);
+    undefined removeContentScripts(sequence<DOMString>? scriptNameList);
 
     // Configuration methods.
     undefined clearData();
@@ -522,6 +522,37 @@ IWA frame will have access to a ControlledFrame element.
 <!-- ====================================================================== -->
 ## Scripting methods ## {#api-scripting}
 <!-- ====================================================================== -->
+
+<xmp class="idl">
+dictionary InjectDetails {
+  DOMString? code;
+  DOMString? file;
+};
+
+dictionary InjectionItems {
+  DOMString code;
+  sequence<DOMString> files;
+};
+
+enum RunAt {
+  "document_start",
+  "document_end",
+  "document_idle",
+};
+
+dictionary ContentScriptDetails {
+  boolean? all_frames;
+  InjectionItems? css;
+  sequence<DOMString>? exclude_globs;
+  sequence<DOMString>? exclude_matches;
+  sequence<DOMString>? include_globs;
+  InjectionItems? js;
+  boolean? match_about_blank;
+  sequence<DOMString> matches;
+  DOMString name;
+  RunAt? run_at;
+};
+</xmp>
 
 <!-- ====================================================================== -->
 ## Configuration methods ## {#api-config}

--- a/index.bs
+++ b/index.bs
@@ -526,8 +526,8 @@ IWA frame will have access to a ControlledFrame element.
 <xmp class="idl">
 // One of |code| or |file| must be specified but not both.
 dictionary InjectDetails {
-  DOMString? code;
-  DOMString? file;
+  DOMString code;
+  DOMString file;
 };
 
 dictionary InjectionItems {
@@ -542,16 +542,16 @@ enum RunAt {
 };
 
 dictionary ContentScriptDetails {
-  boolean? all_frames;
-  InjectionItems? css;
-  sequence<DOMString>? exclude_globs;
-  sequence<DOMString>? exclude_matches;
-  sequence<DOMString>? include_globs;
-  InjectionItems? js;
-  boolean? match_about_blank;
-  sequence<DOMString> matches;
-  DOMString name;
-  RunAt? run_at;
+  boolean all_frames;
+  InjectionItems css;
+  sequence<DOMString> exclude_globs;
+  sequence<DOMString> exclude_matches;
+  sequence<DOMString> include_globs;
+  InjectionItems js;
+  boolean match_about_blank;
+  required sequence<DOMString> matches;
+  required DOMString name;
+  RunAt run_at;
 };
 </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -435,8 +435,8 @@ interface ControlledFrame : HTMLElement {
 
     // Scripting methods.
     undefined addContentScripts(sequence<ContentScriptDetails> contentScriptList);
-    Promise<any> executeScript(optional InjectDetails details);
-    Promise<undefined> insertCSS(optional InjectDetails details);
+    Promise<any> executeScript(optional InjectDetails details = {});
+    Promise<undefined> insertCSS(optional InjectDetails details = {});
     undefined removeContentScripts(sequence<DOMString>? scriptNameList);
 
     // Configuration methods.
@@ -524,6 +524,7 @@ IWA frame will have access to a ControlledFrame element.
 <!-- ====================================================================== -->
 
 <xmp class="idl">
+// One of |code| or |file| must be specified but not both.
 dictionary InjectDetails {
   DOMString? code;
   DOMString? file;

--- a/index.bs
+++ b/index.bs
@@ -435,8 +435,8 @@ interface ControlledFrame : HTMLElement {
 
     // Scripting methods.
     undefined addContentScripts(sequence<ContentScriptDetails> contentScriptList);
-    Promise<any> executeScript(InjectDetails? details);
-    Promise<undefined> insertCSS(InjectDetails? details);
+    Promise<any> executeScript(optional InjectDetails details);
+    Promise<undefined> insertCSS(optional InjectDetails details);
     undefined removeContentScripts(sequence<DOMString>? scriptNameList);
 
     // Configuration methods.


### PR DESCRIPTION
This commit adds the IDL definition for the scripting methods of Controlled Frame. This includes:
* addContentScripts
* executeScript
* insertCSS
* removeContentScript
* and their related types


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/controlled-frame/pull/38.html" title="Last updated on Jan 31, 2024, 10:44 PM UTC (4ef2ee9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/controlled-frame/38/64bb258...odejesush:4ef2ee9.html" title="Last updated on Jan 31, 2024, 10:44 PM UTC (4ef2ee9)">Diff</a>