### PR TITLE
spec: Define configuration methods IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -440,12 +440,14 @@ interface ControlledFrame : HTMLElement {
     undefined removeContentScripts();
 
     // Configuration methods.
-    undefined clearData();
-    undefined getAudioState();
-    undefined getZoom();
-    undefined isAudioMuted();
-    undefined setAudioMuted();
-    undefined setZoom();
+    Promise<undefined> clearData(
+      optional ClearDataOptions options = {},
+      optional ClearDataTypeSet types = {});
+    Promise<boolean> getAudioState();
+    Promise<long> getZoom();
+    Promise<boolean> isAudioMuted();
+    undefined setAudioMuted(boolean mute);
+    Promise<undefined> setZoom(long zoomFactor);
 
     // Capture methods.
     undefined captureVisibleRegion();
@@ -526,6 +528,24 @@ IWA frame will have access to a ControlledFrame element.
 <!-- ====================================================================== -->
 ## Configuration methods ## {#api-config}
 <!-- ====================================================================== -->
+
+<xmp class="idl">
+dictionary ClearDataOptions {
+  long since;
+};
+
+dictionary ClearDataTypeSet {
+  boolean appcache;
+  boolean cache;
+  boolean cookies;
+  boolean fileSystems;
+  boolean indexedDB;
+  boolean localStorage;
+  boolean persistentCookies;
+  boolean sessionCookies;
+  boolean webSQL;
+};
+</xmp>
 
 <!-- ====================================================================== -->
 ## Capture methods ## {#api-capture}


### PR DESCRIPTION
This commit defines the IDL for Controlled Frame's configuration related APIs. These include
* clearData
* getAudioState
* getZoom
* isAudioMuted
* setAudioMuted
* setZoom
* and related types


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/controlled-frame/pull/39.html" title="Last updated on Jan 31, 2024, 11:20 PM UTC (8f41ba3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/controlled-frame/39/64bb258...odejesush:8f41ba3.html" title="Last updated on Jan 31, 2024, 11:20 PM UTC (8f41ba3)">Diff</a>