### PR TITLE
test_app: Add ControlledFrame feature flag to launch command line

### DIFF
--- a/test_app/README.md
+++ b/test_app/README.md
@@ -52,7 +52,7 @@ python3 -m iwa_http_server.py
 2. Execute Chrome with the following flags once.
 
 ```sh
-$CHROME --enable-features=IsolatedWebApps,IsolatedWebAppDevMode
+$CHROME --enable-features=IsolatedWebApps,IsolatedWebAppDevMode,ControlledFrame
 ```
 
 **Optional:** Use the `--user-data-dir` flag to install the IWA in a separate
@@ -60,7 +60,7 @@ Chrome profile. For example:
 
 ```sh
 $CHROME --user-data-dir=$HOME/tmp \
-        --enable-features=IsolatedWebApps,IsolatedWebAppDevMode
+        --enable-features=IsolatedWebApps,IsolatedWebAppDevMode,ControlledFrame
 ```
 
 The user data directory can be cleared to start Chrome in a fresh profile.


### PR DESCRIPTION
Part of recent work separated Controlled Frame from the IWA feature flag. Now, Controlled Frame has to be enabled separately from IWAs.