### PR TITLE
test_app: Set up autorelease

### DIFF
--- a/.github/workflows/build-spec.yml
+++ b/.github/workflows/build-spec.yml
@@ -1,12 +1,14 @@
-name: Build
+name: Build specification
+
 on:
   pull_request: {}
   push:
     branches:
     - main
+
 jobs:
   build:
-    name: Build
+    name: Build specification
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build-test-app.yml
+++ b/.github/workflows/build-test-app.yml
@@ -1,0 +1,59 @@
+name: Build and release test_app
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - test_app/**
+  workflow_dispatch:
+
+jobs:
+  test-build:
+    name: Build and release test_app
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup PNPM
+      uses: pnpm/action-setup@v3
+      with:
+        version: 8
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'pnpm'
+        cache-dependency-path: pnpm-lock.yaml
+    - name: Install dependencies
+      working-directory: ./test_app
+      run: pnpm install
+    - name: Tag
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v6.2
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        tag_prefix: 'test-app-v'
+        default_bump: minor
+    - name: Get all tags
+      uses: octokit/request-action@v2.x
+      id: get_latest_release
+      with:
+        route: GET /repos/${{ github.repository }}/git/matching-refs/tags
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build
+      working-directory: ./test_app
+      run: pnpm bump-version && pnpm build
+      env:
+        KEY: ${{ secrets.KEY }}
+        KEY_PASSPHRASE: ${{ secrets.KEY_PASSPHRASE }}
+        VERSION: ${{ steps.tag_version.outputs.new_tag }}
+        TAGS: ${{ steps.get_latest_release.outputs.data }}
+    - name: Create release
+      uses: ncipollo/release-action@v1
+      with:
+        tag: ${{ steps.tag_version.outputs.new_tag }}
+        name: Release ${{ steps.tag_version.outputs.new_tag }}
+        body: ${{ steps.tag_version.outputs.changelog }}
+        artifacts: './dist/controlled-frame-test-app.swbn,./controlled-frame-test-app-update.json'

--- a/test_app/bump_version.js
+++ b/test_app/bump_version.js
@@ -1,0 +1,43 @@
+import fs from 'fs';
+
+const tagPrefix = 'test-app-v';
+const version = process.env?.VERSION;
+
+if (version) {
+  version = version.replace(tagPrefix, '');
+} else {
+  throw new Error('No version found');
+}
+
+const manifest = JSON.parse(
+  fs.readFileSync('./public/.well-known/manifest.webmanifest', 'utf-8'),
+);
+
+manifest.version = version;
+
+fs.writeFileSync(
+  './public/.well-known/manifest.webmanifest',
+  JSON.stringify(manifest, null, 2),
+);
+
+let versions;
+
+try {
+  versions = JSON.parse(process.env.TAGS)
+    .filter((tag) => tag.startsWith(tagPrefix))
+    .map((tag) => {
+      const v = tag.ref.replace(tagPrefix, '');
+      return {
+        version: v,
+        src: `https://github.com/WICG/controlled-frame/releases/download/${tagPrefix}${v}/controlled-frame-test-app.swbn`,
+      };
+    });
+} catch (e) {
+  throw new Error('No tags');
+}
+
+const updateManifest = {
+  versions,
+};
+
+fs.writeFileSync('./controlled-frame-test-app-update.json', JSON.stringify(updateManifest));

--- a/test_app/package.json
+++ b/test_app/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "bump-version": "node ./bump_version.js"
   },
   "dependencies": {
     "lit": "^3.2.1"


### PR DESCRIPTION
This attempts to create a workflow that will automatically run whenever a commit changes anything in test_app. It will bump the version number (in the test-app-vX tag), build the app, generate an update manifest, and publish a new release with the new swbn file and an update manifest with all known versions.

This is based on the auto-deploy setup in https://github.com/chromeos/iwa-sink, with some additional complexity to deal with the fact that test_app isn't the only thing in this repo.