### PR TITLE
spec: Define WebRequest IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -614,7 +614,7 @@ callback interface WebRequestEventListener {
 };
 
 dictionary RequestFilter {
-  ResourceType[] types;
+  sequence<ResourceType> types;
   USVString[] urls;
   long windowId;
 };

--- a/index.bs
+++ b/index.bs
@@ -627,10 +627,11 @@ enum ExtraInfoSpec {
   "responseHeaders",
 };
 
+[Exposed=Window, SecureContext]
 interface WebRequestEvent {
   undefined addListener(WebRequestEventListener listener,
-                        RequestFilter? filter,
-                        sequence<ExtraInfoSpec>? extraInfoSpec);
+                        optional RequestFilter filter,
+                        optional sequence<ExtraInfoSpec> extraInfoSpec);
   boolean hasListener(WebRequestEventListener listener);
   boolean hasListeners();
   undefined removeListener(WebRequestEventListener listener);
@@ -748,6 +749,7 @@ dictionary WebRequestErrorOccurredDetails : WebRequestEventDetails {
 
 callback HandlerBehaviorChangedCallback = undefined ();
 
+[Exposed=Window, SecureContext]
 interface WebRequest {
   readonly attribute WebRequestEvent onBeforeRequest;
   readonly attribute WebRequestEvent onBeforeSendHeaders;
@@ -759,7 +761,7 @@ interface WebRequest {
   readonly attribute WebRequestEvent onCompleted;
   readonly attribute WebRequestEvent onErrorOccurred;
 
-  undefined handlerBehaviorChanged(HandlerBehaviorChangedCallback? callback);
+  undefined handlerBehaviorChanged(optional HandlerBehaviorChangedCallback callback);
 };
 </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -630,7 +630,7 @@ enum ExtraInfoSpec {
 [Exposed=Window, SecureContext]
 interface WebRequestEvent {
   undefined addListener(WebRequestEventListener listener,
-                        optional RequestFilter filter,
+                        optional RequestFilter filter = {},
                         optional sequence<ExtraInfoSpec> extraInfoSpec);
   boolean hasListener(WebRequestEventListener listener);
   boolean hasListeners();

--- a/index.bs
+++ b/index.bs
@@ -588,6 +588,182 @@ dictionary ClearDataTypeSet {
 <!-- ====================================================================== -->
 
 <!-- ====================================================================== -->
+## Web Request API ## {#api-web-request}
+<!-- ====================================================================== -->
+
+<xmp class="idl">
+enum ResourceType {
+  "main_frame",
+  "sub_frame",
+  "stylesheet",
+  "script",
+  "image",
+  "font",
+  "object",
+  "xmlhttprequest",
+  "ping",
+  "csp_report",
+  "media",
+  "websocket",
+  "webbundle",
+  "other",
+};
+
+callback interface WebRequestEventListener {
+  BlockingResponse? handleEvent(WebRequestEventDetails details);
+};
+
+dictionary RequestFilter {
+  ResourceType[] types;
+  USVString[] urls;
+  long windowId;
+};
+
+enum ExtraInfoSpec {
+  "asyncBlocking",
+  "blocking",
+  "extraHeaders",
+  "requestHeaders",
+  "responseHeaders",
+};
+
+interface WebRequestEvent {
+  undefined addListener(WebRequestEventListener listener,
+                        RequestFilter? filter,
+                        ExtraInfoSpec[]? extraInfoSpec);
+  boolean hasListener(WebRequestEventListener listener);
+  boolean hasListeners();
+  undefined removeListener(WebRequestEventListener listener);
+};
+
+dictionary HttpHeader {
+  required DOMString name;
+  DOMString value;
+  byte[] binaryValue;
+};
+
+dictionary WebRequestAuthCredentials {
+  required DOMString username;
+  required DOMString password;
+};
+
+dictionary BlockingResponse {
+  WebRequestAuthCredentials authCredentials;
+  boolean cancel;
+  USVString redirectUrl;
+  HttpHeader[] requestHeaders;
+  HttpHeader[] responseHeaders;
+};
+
+enum DocumentLifecycle {
+  "prerender",
+  "active",
+  "cached",
+  "pending_deletion",
+};
+
+enum FrameType {
+  "outermost_frame",
+  "fenced_frame",
+  "sub_frame",
+};
+
+dictionary WebRequestEventDetails {
+  DOMString documentId;
+  DocumentLifecycle documentLifecycle;
+  required long frameId;
+  FrameType frameType;
+  USVString initiator;
+  required DOMString method;
+  DOMString parentDocumentId;
+  required long parentFrameId;
+  required DOMString requestId;
+  required long timeStamp;
+  required ResourceType type;
+  required USVString url;
+};
+
+dictionary WebRequestEventResponseDetails : WebRequestEventDetails {
+  required long statusCode;
+  required DOMString statusLine;
+  HttpHeader[] responseHeaders;
+};
+
+dictionary UploadData {
+  ArrayBuffer bytes;
+  DOMString file;
+};
+dictionary RequestBody {
+  DOMString error;
+  any formData;
+  UploadData[] raw;
+};
+
+dictionary WebRequestBeforeRequestDetails : WebRequestEventDetails {
+  RequestBody requestBody;
+};
+
+dictionary WebRequestBeforeSendHeadersDetails : WebRequestEventDetails {
+  HttpHeader[] requestHeaders;
+};
+
+dictionary WebRequestSendHeadersDetails : WebRequestEventDetails {
+  HttpHeader[] requestHeaders;
+};
+
+dictionary WebRequestHeadersReceivedDetails : WebRequestEventResponseDetails {};
+
+dictionary AuthChallenger {
+  DOMString host;
+  long port;
+};
+dictionary WebRequestAuthRequiredDetails : WebRequestEventResponseDetails {
+  required AuthChallenger challenger;
+  required boolean isProxy;
+  required DOMString scheme;
+  DOMString realm;
+};
+
+dictionary WebRequestBeforeRedirectDetails : WebRequestEventResponseDetails {
+  required boolean fromCache;
+  DOMString ip;
+  required USVString redirectUrl;
+};
+
+dictionary WebRequestResponseStartedDetails : WebRequestEventResponseDetails {
+  required boolean fromCache;
+  DOMString ip;
+};
+
+dictionary WebRequestCompletedDetails : WebRequestEventResponseDetails {
+  required boolean fromCache;
+  DOMString ip;
+};
+
+dictionary WebRequestErrorOccurredDetails : WebRequestEventDetails {
+  required DOMString error;
+  required boolean fromCache;
+  DOMString ip;
+};
+
+callback HandlerBehaviorChangedCallback = undefined ();
+
+interface WebRequest {
+  readonly attribute WebRequestEvent onBeforeRequest;
+  readonly attribute WebRequestEvent onBeforeSendHeaders;
+  readonly attribute WebRequestEvent onSendHeaders;
+  readonly attribute WebRequestEvent onHeadersReceived;
+  readonly attribute WebRequestEvent onAuthRequired;
+  readonly attribute WebRequestEvent onBeforeRedirect;
+  readonly attribute WebRequestEvent onResponseStarted;
+  readonly attribute WebRequestEvent onCompleted;
+  readonly attribute WebRequestEvent onErrorOccurred;
+
+  undefined handlerBehaviorChanged(HandlerBehaviorChangedCallback? callback);
+};
+</xmp>
+
+<!-- ====================================================================== -->
 # Controlled Frame API # {#controlled-frame-api}
 <!-- ====================================================================== -->
 

--- a/index.bs
+++ b/index.bs
@@ -615,7 +615,7 @@ callback interface WebRequestEventListener {
 
 dictionary RequestFilter {
   sequence<ResourceType> types;
-  USVString[] urls;
+  sequence<USVString> urls;
   long windowId;
 };
 
@@ -630,7 +630,7 @@ enum ExtraInfoSpec {
 interface WebRequestEvent {
   undefined addListener(WebRequestEventListener listener,
                         RequestFilter? filter,
-                        ExtraInfoSpec[]? extraInfoSpec);
+                        sequence<ExtraInfoSpec>? extraInfoSpec);
   boolean hasListener(WebRequestEventListener listener);
   boolean hasListeners();
   undefined removeListener(WebRequestEventListener listener);
@@ -639,7 +639,7 @@ interface WebRequestEvent {
 dictionary HttpHeader {
   required DOMString name;
   DOMString value;
-  byte[] binaryValue;
+  sequence<byte> binaryValue;
 };
 
 dictionary WebRequestAuthCredentials {
@@ -651,8 +651,8 @@ dictionary BlockingResponse {
   WebRequestAuthCredentials authCredentials;
   boolean cancel;
   USVString redirectUrl;
-  HttpHeader[] requestHeaders;
-  HttpHeader[] responseHeaders;
+  sequence<HttpHeader> requestHeaders;
+  sequence<HttpHeader> responseHeaders;
 };
 
 enum DocumentLifecycle {
@@ -686,7 +686,7 @@ dictionary WebRequestEventDetails {
 dictionary WebRequestEventResponseDetails : WebRequestEventDetails {
   required long statusCode;
   required DOMString statusLine;
-  HttpHeader[] responseHeaders;
+  sequence<HttpHeader> responseHeaders;
 };
 
 dictionary UploadData {
@@ -696,7 +696,7 @@ dictionary UploadData {
 dictionary RequestBody {
   DOMString error;
   any formData;
-  UploadData[] raw;
+  sequence<UploadData> raw;
 };
 
 dictionary WebRequestBeforeRequestDetails : WebRequestEventDetails {
@@ -704,11 +704,11 @@ dictionary WebRequestBeforeRequestDetails : WebRequestEventDetails {
 };
 
 dictionary WebRequestBeforeSendHeadersDetails : WebRequestEventDetails {
-  HttpHeader[] requestHeaders;
+  sequence<HttpHeader> requestHeaders;
 };
 
 dictionary WebRequestSendHeadersDetails : WebRequestEventDetails {
-  HttpHeader[] requestHeaders;
+  sequence<HttpHeader> requestHeaders;
 };
 
 dictionary WebRequestHeadersReceivedDetails : WebRequestEventResponseDetails {};


### PR DESCRIPTION
This defines the IDL of the Controlled Frame WebRequest API, but does not include any normative or non-normative text further specifying it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/robbiemc/controlled-frame/pull/58.html" title="Last updated on Jan 28, 2025, 11:43 PM UTC (816aa03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/controlled-frame/58/c10e650...robbiemc:816aa03.html" title="Last updated on Jan 28, 2025, 11:43 PM UTC (816aa03)">Diff</a>