### PR TITLE
spec: Update addContentScripts and removeContentScripts to be async

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -152,10 +152,10 @@ interface HTMLControlledFrameElement : HTMLElement {
     undefined stop();
 
     // Scripting methods.
-    undefined addContentScripts(sequence<ContentScriptDetails> contentScriptList);
+    Promise<undefined> addContentScripts(sequence<ContentScriptDetails> contentScriptList);
     Promise<any> executeScript(optional InjectDetails details = {});
     Promise<undefined> insertCSS(optional InjectDetails details = {});
-    undefined removeContentScripts(sequence<DOMString>? scriptNameList);
+    Promise<undefined> removeContentScripts(sequence<DOMString>? scriptNameList);
 
     // Configuration methods.
     Promise<undefined> clearData(


### PR DESCRIPTION
As part of fixes to the implementation, we made these promise-based. Update the spec to reflect that change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/controlled-frame/pull/63.html" title="Last updated on Feb 4, 2025, 1:06 AM UTC (b7140a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/controlled-frame/63/4ea8de3...b7140a6.html" title="Last updated on Feb 4, 2025, 1:06 AM UTC (b7140a6)">Diff</a>