### PR TITLE
spec: Add element categories

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -181,6 +181,12 @@ patching specifications for some parts of this Controlled Frame specification.
 <!-- ====================================================================== -->
 
 <dl class="element">
+ <dt>[=Categories=]:</dt>
+ <dd>[=Flow content=].</dd>
+ <dd>[=Phrasing content=].</dd>
+ <dd>[=Embedded content=].</dd>
+ <dd>[=Interactive content=].</dd>
+ <dd>[=Palpable content=].</dd>
  <dt>[=Contexts in which this element can be used=]:</dt>
  <dd>Where [=embedded content=] is expected.</dd>
  <dt>[=Content model=]:</dt>


### PR DESCRIPTION
This adds a "Categories" section to the element definition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/robbiemc/controlled-frame/pull/83.html" title="Last updated on Mar 5, 2025, 12:28 AM UTC (5dcd915)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/controlled-frame/83/a61ea26...robbiemc:5dcd915.html" title="Last updated on Mar 5, 2025, 12:28 AM UTC (5dcd915)">Diff</a>