### PR TITLE
spec: Miscellaneous cleanup

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -477,7 +477,8 @@ Controlled Frame's [=embedded navigable=] will persist.
 
 If the partition attribute identifier contains the prefix "persist:", the user
 agent will use a disk-based storage environment rather than an in-memory
-storage partition.
+storage partition. Embedded content should not be able to detect whether its
+storage is in-memory or persistent.
 
 If multiple Controlled Frames share the same partition identifier, all of their
 [=embedded navigable=] instances will share the same storage partition.
@@ -610,8 +611,7 @@ Frame's [=embedded navigable=]'s [=current session history entry=]'s
   1. If |result| is not equal to "`applied`", [=resolve=] |resultPromise|
       with false.
 
-  1. <span class=XXX>TODO: resolve the promise when the navigation
-      completes</span>.
+  1. Otherwise, [=resolve=] |resultPromise| with true.
 
 </div>
 
@@ -621,8 +621,7 @@ Frame's [=embedded navigable=]'s [=current session history entry=]'s
 
   ISSUE: We can't actually synchronously access the embedded navigable's
   history state. In the future we should update this method to return a
-  Promise, but in the meantime we should keep track of the embedded
-  navigable's navigation state by observing its navigations.
+  Promise.
 
   1. If [=this=]'s [=embedded navigable=] is null, then return false.
 
@@ -766,13 +765,6 @@ A <dfn>content script config</dfn> is a [=struct=] with the following
       document's lifecycle.
 
 </dl>
-
-<div algorithm>
-  The <dfn>validate embedded content</dfn> algorithm is obsolete and is in
-  the process of being removed from this spec.
-
-  <span class=XXX>Remove all callers of this algorithm.</span>
-</div>
 
 <div algorithm>
   To <dfn>fetch an injection item</dfn> given a <{controlledframe}>
@@ -1066,9 +1058,9 @@ implementation of this isolation that can be implemented by all browsers.
 
   1. Let |result| be a new [=promise=].
 
-  1. Return |promise| and run the remaining steps [=in parallel=].
+  1. Return |result| and run the remaining steps [=in parallel=].
 
-  1. If [=this=]'s [=embedded navigable=] is null, [=reject=] |promise| with a
+  1. If [=this=]'s [=embedded navigable=] is null, [=reject=] |result| with a
       {{TypeError}} and abort these steps.
 
   1. If |details|["{{InjectDetails/code}}"] and
@@ -1089,11 +1081,11 @@ implementation of this isolation that can be implemented by all browsers.
 
       1. If |status| is a [=normal completion=], then:
 
-          1. [=Resolve=] |promise| with |status|.`[[Value]]`.
+          1. [=Resolve=] |result| with |status|.`[[Value]]`.
 
       1. Otherwise:
 
-          1. [=Reject=] |promise| with |status|.`[[Value]]`.
+          1. [=Reject=] |result| with |status|.`[[Value]]`.
 
   1. If |details|["{{InjectDetails/code}}"] is defined, then run
       |executionSteps| given 0 and |details|["{{InjectDetails/code}}"].
@@ -1167,9 +1159,7 @@ dictionary ClearDataTypeSet {
   method steps are:
 
   1. Let |resultPromise| be a new [=promise=].
-  1. If the result of running [=validate embedded content=] is false,
-     [=reject=] |resultPromise| with
-      a {{TypeError}} and abort these steps.
+  1. Return |resultPromise| and run the remaining steps [=in parallel=].
   1. Let |clearSince| be 0. This will represent to clear all items.
   1. If |options|["since"] is set:
       1. Let |clearSince| be |options|["since"].
@@ -1200,9 +1190,9 @@ dictionary ClearDataTypeSet {
   method steps are:
 
   1. Let |resultPromise| be a new [=promise=].
-  1. If the result of running [=validate embedded content=] is false,
-     [=reject=] |resultPromise| with
-      a {{TypeError}} and abort these steps.
+  1. Return |resultPromise| and run the remaining steps [=in parallel=].
+  1. If [=this=]'s [=embedded navigable=] is null, then [=reject=]
+      |resultPromise| with a {{TypeError}} and abort these steps.
   1. Let |muteState| be the current audio mute state of embedded content.
   1. Then, [=resolve=] |resultPromise| with |muteState|.
 
@@ -1213,9 +1203,9 @@ dictionary ClearDataTypeSet {
   method steps are:
 
   1. Let |resultPromise| be a new [=promise=].
-  1. If the result of running [=validate embedded content=] is false,
-     [=reject=] |resultPromise| with
-      a {{TypeError}} and abort these steps.
+  1. Return |resultPromise| and run the remaining steps [=in parallel=].
+  1. If [=this=]'s [=embedded navigable=] is null, then [=reject=]
+      |resultPromise| with a {{TypeError}} and abort these steps.
   1. Let |zoomFactor| be the current zoom setting for the embedded content.
   1. Then, [=resolve=] |resultPromise| with |zoomFactor|.
 
@@ -1226,8 +1216,9 @@ dictionary ClearDataTypeSet {
   method steps are:
 
   1. Let |resultPromise| be a new [=promise=].
-  1. If the result of running [=validate embedded content=] is false, [=reject=] |resultPromise| with
-      a {{TypeError}} and abort these steps.
+  1. Return |resultPromise| and run the remaining steps [=in parallel=].
+  1. If [=this=]'s [=embedded navigable=] is null, then [=reject=]
+      |resultPromise| with a {{TypeError}} and abort these steps.
   1. Let |muteState| be the current audio mute state for embedded content.
   1. Then, [=resolve=] |resultPromise| with |muteState|.
 
@@ -1237,8 +1228,8 @@ dictionary ClearDataTypeSet {
   The <dfn method for=HTMLControlledFrameElement>setAudioMuted(|mute|)</dfn>
   method steps are:
 
-  1. If the result of running [=validate embedded content=] is false,
-     return false.
+  1. If [=this=]'s [=embedded navigable=] is null, then [=throw=] a
+      {{TypeError}}.
   1. Change the audio mute state for embedded content to match |mute| state.
 
 </div>
@@ -1248,9 +1239,9 @@ dictionary ClearDataTypeSet {
   method steps are:
 
   1. Let |resultPromise| be a new [=promise=].
-  1. If the result of running [=validate embedded content=] is false,
-     [=reject=] |resultPromise| with
-      a {{TypeError}} and abort these steps.
+  1. Return |resultPromise| and run the remaining steps [=in parallel=].
+  1. If [=this=]'s [=embedded navigable=] is null, then [=reject=]
+      |resultPromise| with a {{TypeError}} and abort these steps.
   1. Change  the zoom for the embedded content to be |zoomFactor|.
   1. Then, [=resolve=] |resultPromise|.
 
@@ -1273,9 +1264,9 @@ dictionary ImageDetails {
   method steps are:
 
   1. Let |resultPromise| be a new [=promise=].
-  1. If the result of running [=validate embedded content=] is false,
-     [=reject=] |resultPromise| with
-      a {{TypeError}} and abort these steps.
+  1. Return |resultPromise| and run the remaining steps [=in parallel=].
+  1. If [=this=]'s [=embedded navigable=] is null, then [=reject=]
+      |resultPromise| with a {{TypeError}} and abort these steps.
   1. Let |optionsFormat| be "JPEG" by default.
   1. Let |optionsQuality| be 100 by default.
   1. If |options| has field "format":
@@ -1300,8 +1291,8 @@ dictionary ImageDetails {
   The <dfn method for=HTMLControlledFrameElement>print()</dfn>
   method steps are:
 
-  1. If the result of running [=validate embedded content=] is false,
-     abort these steps.
+  1. If [=this=]'s [=embedded navigable=] is null, then [=throw=] a
+      {{TypeError}}.
   1. Initiate the browser print page feature for embedded content.
 
 </div>
@@ -1796,6 +1787,30 @@ monkey patched as follows:
 <span class=XXX>TODO: Monkeypatch in calls to the [=inject content scripts into
 a document=] algorithm.</span>
 
+#### [[FETCH]] #### {#api-monkey-patches-fetch}
+
+The [=determine the network partition key=] algorithm is monkey extended to
+require double-keying on network requests originating from a Controlled Frame's
+[=embedded navigable=].
+
+<div algorithm="determine the network partition key controlled frame">
+To determine the network partition key, given an [=environment=] |environment|:
+
+  4. Let |topLevelSite| be the result of [=obtaining a site=], given
+      topLevelOrigin.
+
+  5. Let |secondKey| be null or an [=implementation-defined=] value.
+
+  6. <ins>Let |embedderParent| be the result of [=getting an environment's
+      embedderParent=] given |environment|.</ins>
+
+  7. <ins>If |embedderParent| is not null, then set |secondKey| to
+      |embedderParent|'s {{HTMLControlledFrameElement/partition}}.</ins>
+
+  8. Return (|topLevelSite|, |secondKey|).
+
+</div>
+
 #### [[STORAGE]] #### {#api-monkey-patches-storage}
 
 The [=obtain a storage key for non-storage purposes=] algorithm is extended to
@@ -1810,27 +1825,38 @@ To obtain a storage key for non-storage purposes, given an [=environment=]
       |environment| is an [=environment settings object=]; otherwise
       |environment|'s [=creation URL=]'s [=/origin=].
 
+  1. <ins>Let |embedderParent| be the result of [=getting an environment's
+      embedderParent=] given |environment|.</ins>
+
+  1. <ins>If |embedderParent| is not null, then return a [=tuple=] consisting
+      of |embedderParent|'s {{HTMLControlledFrameElement/partition}} and
+      |origin|.</ins>
+
+  1. Return a [=tuple=] consisting of |origin|.
+
+</div>
+
+<div algorithm>
+To <dfn>get an [=environment=]'s [=embedderParent=]</dfn> given an
+[=environment=] |environment|, run the following steps:
+
   1. If |environment| is an [=environment settings object=] whose
       [=global object=] is a {{Window}} object, then:
 
-      Issue: This algorithm doesn't handle partitioning Shared or Service
-      Workers. If initiated from a document, Shared and Service Workers will
-      inherit the storage key of the document, but won't correctly inherit
-      the embedded storage key if started from another worker.
+      Issue: This algorithm doesn't work for Shared or Service Workers because
+      [=embedderParent=] is only defined on a [=/navigable=], and it's not
+      always possible to go from a non-{{Window}} [=environment=] to a
+      [=/navigable=].
 
       1. Let |navigable| be |environment|'s [=global object=]'s
           [=Window/navigable=].
 
-      1. Let |root| be the [=top-level traversable=] of |navigable|.
+      1. Let |top| be the [=top-level traversable=] of |navigable|.
 
-      1. If |root|'s [=embedderParent=] is not null, then:
+      1. If |top|'s [=embedderParent=] is not null, then return |top|'s
+          [=embedderParent=].
 
-          1. Let |controlledframe| be |root|'s [=embedderParent=].
-
-          1. Return a [=tuple=] consisting of |controlledframe|'s
-              {{HTMLControlledFrameElement/partition}} and |origin|.
-
-  1. Return a [=tuple=] consisting of |origin|.
+  1. Return null.
 
 </div>
 


### PR DESCRIPTION
This makes a few changes, mostly based on feedback from #78:

- Noted that the "persist:" partition prefix should be opaque to embedded content.
- Removed TODO about waiting for navigation completion. As far as I can tell the navigation algorithm we're calling already waits for completion.
- Replaced remaining uses of "validate embedded content" with embedderParent null checks.
  - This touched most of the configuration/capture methods to somewhat improve them, but more work is needed on them.
- Added double keying to the network partition key.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/robbiemc/controlled-frame/pull/90.html" title="Last updated on Mar 25, 2025, 12:02 AM UTC (20a3178)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/controlled-frame/90/7bab23e...robbiemc:20a3178.html" title="Last updated on Mar 25, 2025, 12:02 AM UTC (20a3178)">Diff</a>