### PR TITLE
spec: Remove Promise.all and remove optional in definition parameters

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -200,6 +200,7 @@ spec: webidl; urlPrefix: https://webidl.spec.whatwg.org
         text: promise; url: idl-promise
         text: promise rejected; url: a-promise-rejected-with
         text: promise resolved; url: a-promise-resolved-with
+        text: getting a promise for waiting for all promises; url: waiting-for-all-promise
 
 spec: uievents; urlPrefix: https://www.w3.org/TR/uievents/
     type: dfn
@@ -1209,7 +1210,7 @@ implementation of this isolation that can be implemented by all browsers.
 
       1. [=list/Append=] |promise| to |promises|.
 
-  1. Return the result of calling {{Promise}}.{{Promise/all}} given |promises|.
+  1. Return the result of [=getting a promise for waiting for all promises=] given |promises|.
 
 </div>
 
@@ -1234,7 +1235,7 @@ implementation of this isolation that can be implemented by all browsers.
 </div>
 
 <div algorithm>
-  The <dfn method for=HTMLControlledFrameElement>executeScript(optional |details|)</dfn>
+  The <dfn method for=HTMLControlledFrameElement>executeScript(|details|)</dfn>
   method steps are:
 
   1. Let |result| be [=a new promise=].
@@ -1283,7 +1284,7 @@ implementation of this isolation that can be implemented by all browsers.
 </div>
 
 <div algorithm>
-  The <dfn method for=HTMLControlledFrameElement>insertCSS(optional |details|)</dfn>
+  The <dfn method for=HTMLControlledFrameElement>insertCSS(|details|)</dfn>
   method steps are:
 
   1. Let |result| be [=a new promise=].
@@ -1362,7 +1363,7 @@ dictionary ClearDataTypeSet {
 </div>
 
 <div algorithm>
-  The <dfn method for=HTMLControlledFrameElement>clearData(optional |options|, optional |types|)</dfn>
+  The <dfn method for=HTMLControlledFrameElement>clearData(|options|, |types|)</dfn>
   method steps are:
 
   1. Let |resultPromise| be [=a new promise=].
@@ -1712,7 +1713,7 @@ dictionary ImageDetails {
 </xmp>
 
 <div algorithm>
-  The <dfn method for=HTMLControlledFrameElement>captureVisibleRegion(optional |options|)</dfn>
+  The <dfn method for=HTMLControlledFrameElement>captureVisibleRegion(|options|)</dfn>
   method steps are:
 
   1. Let |resultPromise| be [=a new promise=].


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ZelinLiu2022/controlled-frame/pull/115.html" title="Last updated on May 8, 2025, 9:00 PM UTC (b095c69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/controlled-frame/115/ae483d9...ZelinLiu2022:b095c69.html" title="Last updated on May 8, 2025, 9:00 PM UTC (b095c69)">Diff</a>