### PR TITLE
spec: Use 'parse a URL' instead of 'URL parser'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -458,7 +458,7 @@ are [=content script config=]s.
 
   1. If |urlString| is not an [=absolute-URL string=], return.
 
-  1. Let |url| be the result of running the [=URL parser=] given |urlString|.
+  1. Let |url| be the result of [=parsing a URL=] given |urlString| and |element|'s [=node document=].
 
   1. Let |historyHandling| be "{{NavigationHistoryBehavior/auto}}".
 
@@ -963,8 +963,8 @@ A <dfn>content script config</dfn> is a [=struct=] with the following
 
   1. Let |request| be a new [=request=] with the following fields:
       : [=request/URL=]
-      :: The result of running the [=URL parser=] given |urlString| and
-          |controlledframe|'s [=node document=]'s [=document base URL=]
+      :: The result of [=parsing a URL=] given |urlString| and
+          |controlledframe|'s [=node document=].
       : [=request/method=]
       :: "`GET`"
       : [=request/destination=]


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ZelinLiu2022/controlled-frame/pull/119.html" title="Last updated on May 13, 2025, 2:04 AM UTC (47ab39f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/controlled-frame/119/6f19a98...ZelinLiu2022:47ab39f.html" title="Last updated on May 13, 2025, 2:04 AM UTC (47ab39f)">Diff</a>