### PR TITLE
spec: Fire LoadRedirectEvent now takes URL instead of USVString

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -200,6 +200,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org
         text: storage shed; url: storage-shed
         text: storage shelf; url: storage-shelf
 
+spec: url; urlPrefix: https://url.spec.whatwg.org/
+    type: dfn
+        urlPrefix: /
+            text: serialize an URL; url: concept-url-serializer
+
 spec: webidl; urlPrefix: https://webidl.spec.whatwg.org
     type: dfn
         text: Web IDL Standard; url: introduction
@@ -2714,16 +2719,16 @@ dictionary LoadRedirectEventInit: EventInit {
 <div algorithm=dispatch-loadredirect>
 
 To <dfn data-lt='fire a "loadredirect" event'>fire a {{LoadRedirectEvent}}</dfn>
-|e| given <{controlledframe}> element |target|, a USVString |oldUrl|, a
-USVString |newUrl|, and a boolean |isTopLevel|, run the following steps:
+|e| given <{controlledframe}> element |target|, an [=/URL=] |oldUrl|, an
+[=/URL=] |newUrl|, and a boolean |isTopLevel|, run the following steps:
 
 1. Let |info| be a [=new=] {{LoadInfo}} with the following attributes:
 
       : {{LoadRedirectInfo/oldUrl}}
-      :: |oldUrl|
+      :: The result of [=serializing an URL=] given |oldUrl|
 
       : {{LoadRedirectInfo/newUrl}}
-      :: |newUrl|
+      :: The result of [=serializing an URL=] given |newUrl|
 
       : {{LoadRedirectInfo/isTopLevel}}
       :: |isTopLevel|


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ZelinLiu2022/controlled-frame/pull/123.html" title="Last updated on May 14, 2025, 6:06 PM UTC (b58d400)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/controlled-frame/123/d61b659...ZelinLiu2022:b58d400.html" title="Last updated on May 14, 2025, 6:06 PM UTC (b58d400)">Diff</a>