### PR TITLE
spec: Add a11y considerations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -305,9 +305,14 @@ patching specifications for some parts of this Controlled Frame specification.
  <dd><code>{{src}}</code> — Content source URL to embed</dd>
  <dd><code>{{partition}}</code> — Partition name to hold data related to this content</dd>
  <dt>[=Accessibility considerations=]:</dt>
- <dd><p class=XXX>Screen readers should be able to traverse into
- the embedded content similar to how a reader can traverse into iframes and
- other related embedded content.</p></dd>
+ <dd><a href="https://w3c.github.io/html-aria/#el-iframe">For authors</a>.</dd>
+ <dd><a href="https://w3c.github.io/html-aam/#el-iframe">For implementers</a>.</dd>
+ <dd>
+
+    Note: These link to the accessibility definitions of the <{iframe}> element.
+    From an accessibility perspective, a <{controlledframe}> should behave the
+    same as an <{iframe}>.
+ </dd>
  <dt>[=DOM interface=]:</dt>
  <dd>
 <xmp class=idl>


### PR DESCRIPTION
This adds links to the iframe a11y rules, which are the same as what we want.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/robbiemc/controlled-frame/pull/133.html" title="Last updated on May 15, 2025, 8:00 PM UTC (d0177c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/controlled-frame/133/48e2e71...robbiemc:d0177c7.html" title="Last updated on May 15, 2025, 8:00 PM UTC (d0177c7)">Diff</a>