### PR TITLE
spec: Remove WebRequest.interceptorBehaviorChanged

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3140,8 +3140,6 @@ dictionary WebRequestInterceptorOptions {
 interface WebRequest {
   WebRequestInterceptor createWebRequestInterceptor(
       WebRequestInterceptorOptions options);
-
-  Promise<undefined> interceptorBehaviorChanged();
 };
 
 [Exposed=Window, IsolatedContext]
@@ -3577,43 +3575,6 @@ Each {{WebRequestResponseStartedEvent}} has an associated:
   1. [=list/Append=] |interceptor| to [=this=]'s [=WebRequest/interceptors=].
 
   1. Return |interceptor|.
-
-</div>
-
-<div algorithm>
-  The <dfn method for=WebRequest>interceptorBehaviorChanged()</dfn>
-  method steps are:
-
-  Note: The behavior of event handlers registered through the WebRequest
-  API will be reflected in the HTTP cache, which will no longer be valid if
-  the behavior of the event handlers changed. The purpose of this method is
-  to invalidate any cache entries that were affected by WebRequest event
-  handlers.
-
-  1. Let |promise| be [=a new promise=].
-
-  1. Let |controlledframe| be [=this=].
-
-  1. Return |promise| and run the following steps [=in parallel=].
-
-  1. Remove all entries in the
-      <a href="https://datatracker.ietf.org/doc/html/rfc7234#section-2">network
-      cache</a> that originated from content in |controlledframe|'s
-      <{HTMLControlledFrameElement/partition}>.
-
-      Issue: The <a href="https://datatracker.ietf.org/doc/html/rfc7234#section-2">
-          network cache</a> specification isn't aware of [=storage keys=]. The
-          intended behavior is to remove cache entries whose [=storage key/
-          embedding origin=] is |controlledframe|'s [=relevant settings object=]'s
-          [=environment/top-level origin=], and [=storage key/partition=]
-          is |controlledframe|'s <{HTMLControlledFrameElement/partition}>.
-
-  1. If a user agent implements caches beyond a pure network cache, it MUST
-      remove all entries from those caches that originate from content in
-      |controlledframe|'s <{HTMLControlledFrameElement/partition}>.
-
-  1. [=Resolve an embedder promise=] given |controlledframe| and |promise| when
-      the HTTP cache has been cleared.
 
 </div>
 


### PR DESCRIPTION
This was originally here due to a misunderstanding in the original documentation. This method isn't actually defined, and isn't needed because the cache can be cleared with clearData if needed.